### PR TITLE
Base image on alpine to reduce size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,11 @@
-FROM python:3
+FROM python:alpine3.12
 
 WORKDIR /usr/src/app
 
 COPY requirements.txt ./
-RUN pip install --no-cache-dir -r requirements.txt
+RUN apk add g++ && \
+    pip install --no-cache-dir -r requirements.txt && \
+    apk del g++
 
 COPY . .
 


### PR DESCRIPTION
This saves about 844MB.

This new image was already pushed to docker.io and tested in Cilium e2e CI at cilium/cilium#12583.

Related: cilium/packer-ci-build#227